### PR TITLE
added routes for existing figma pages

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,2 +1,11 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation</p>
+<h1>ClassConnect Landing Page / Dashboard :)</h1>
+
+<p>I think I did the routing correctly</p>
+
+<p>TODO:</p>
+<ul>
+    <li>Add tailwind(?)</li>
+</ul>
+
+<a href="/calendar">Calendar</a>
+<a href="/profile">Profile</a>

--- a/src/routes/calendar/+page.svelte
+++ b/src/routes/calendar/+page.svelte
@@ -1,0 +1,9 @@
+<h1>Calendar Lives Here</h1>
+
+<a href="/">Dashboard</a>
+<a href="/profile">Profile</a>
+
+<p>TODO:</p>
+<ul>
+    <li>Add Calendar Component</li>
+</ul>

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -1,0 +1,9 @@
+<h1>Profile</h1>
+
+<a href="/">Dashboard</a>
+<a href="/calendar">Calendar</a>
+
+<p>TODO:</p>
+<ul>
+    <li>Figure out if we need a [slug] route instead for the changing profile views</li>
+</ul>


### PR DESCRIPTION
### Problem ###

App needs routes for existing pages in the figma.

### Solution ###

Added basic routes for Dashboard, Calendar, and Profile.

I assumed that both the weekly and daily calendars would be accessible within the same view.
Each page has a link to the other for now.
Need to discuss how we want to route the profile view, since we have TA vs Student