### PR TITLE
Calendar Booking, Part 2

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -90,7 +90,7 @@ async function initializeDatabase() {
 
 	const appointmentBlock2Time = new Date(appointmentBlock1Time);
 
-	appointmentBlock2Time.setDate(appointmentBlock1Time.getDate() + 1);
+	appointmentBlock2Time.setDate(appointmentBlock1Time.getDate() + 2);
 
 	const appointmentBlock1 = await createAppointmentBlock({
 		instructional_member_id: instructionalMember.id,

--- a/src/lib/components/calendar/CalendarBookingModal.svelte
+++ b/src/lib/components/calendar/CalendarBookingModal.svelte
@@ -1,35 +1,41 @@
 <script lang="ts">
 	import { createEventDispatcher } from "svelte";
 	import Modal from "$lib/components/modal/Modal.svelte";
-	import type { ExtendedAppointment, User } from "$lib/types";
+	import type { ExtendedAppointmentBlock, User } from "$lib/types";
 
-	export let appointment: ExtendedAppointment | undefined;
+	export let data:
+		| {
+				appointmentBlock: ExtendedAppointmentBlock;
+				appointmentDate: Date;
+		  }
+		| undefined;
+
 	export let isOpen: boolean;
 
 	const dispatch = createEventDispatcher<{ close: undefined }>();
 
-	function appointmentDateFormatted(appointment: ExtendedAppointment): string {
-		return appointment.appointment_day.toLocaleString("en-US", {
+	function appointmentDateFormatted(appointmentDate: Date): string {
+		return appointmentDate.toLocaleString("en-US", {
 			dateStyle: "long"
 		});
 	}
 
-	function appointmentEndTimeFormatted(appointment: ExtendedAppointment): string {
-		const endTime = new Date(appointment.appointment_block.start_time);
+	function appointmentBlockEndTimeFormatted(appointmentBlock: ExtendedAppointmentBlock): string {
+		const endTime = new Date(appointmentBlock.start_time);
 
-		endTime.setTime(endTime.getTime() + appointment.appointment_block.duration);
+		endTime.setTime(endTime.getTime() + appointmentBlock.duration);
 
 		return endTime.toLocaleString("en-US", {
 			timeStyle: "short"
 		});
 	}
 
-	function appointmentInstructionalMember(appointment: ExtendedAppointment): User {
-		return appointment.appointment_block.instructional_member.user;
+	function appointmentBlockInstructionalMember(appointmentBlock: ExtendedAppointmentBlock): User {
+		return appointmentBlock.instructional_member.user;
 	}
 
-	function appointmentStartTimeFormatted(appointment: ExtendedAppointment): string {
-		return appointment.appointment_block.start_time.toLocaleString("en-US", {
+	function appointmentBlockStartTimeFormatted(appointmentBlock: ExtendedAppointmentBlock): string {
+		return appointmentBlock.start_time.toLocaleString("en-US", {
 			timeStyle: "short"
 		});
 	}
@@ -40,16 +46,17 @@
 	on:close={() => {
 		dispatch("close");
 	}}>
-	{#if appointment != undefined}
+	{#if data != undefined}
 		<h2 class="font-bold text-xl">
-			Book an Appointment with {appointmentInstructionalMember(appointment).first_name}
-			{appointmentInstructionalMember(appointment).last_name}
+			Book an Appointment with {appointmentBlockInstructionalMember(data.appointmentBlock)
+				.first_name}
+			{appointmentBlockInstructionalMember(data.appointmentBlock).last_name}
 		</h2>
 
 		<h3 class="text-sm text-gray-600">
-			{appointmentDateFormatted(appointment)} from {appointmentStartTimeFormatted(appointment)} to {appointmentEndTimeFormatted(
-				appointment
-			)}
+			{appointmentDateFormatted(data.appointmentDate)} from {appointmentBlockStartTimeFormatted(
+				data.appointmentBlock
+			)} to {appointmentBlockEndTimeFormatted(data.appointmentBlock)}
 		</h3>
 	{/if}
 

--- a/src/lib/components/calendar/CalendarCard.svelte
+++ b/src/lib/components/calendar/CalendarCard.svelte
@@ -1,24 +1,60 @@
 <script lang="ts">
 	import { createEventDispatcher } from "svelte";
-	import type { ExtendedAppointment } from "$lib/types";
-	import { sectionName, userName } from "$lib/utils";
+	import { isCalendarEventAppointmentBlock, type CalendarEvent } from "$lib/components/calendar";
+	import type { ExtendedAppointmentBlock, ExtendedSectionMember } from "$lib/types";
+	import { sectionName } from "$lib/utils";
 
-	export let appointment: ExtendedAppointment;
+	export let event: CalendarEvent;
+	export let userID: string;
 	export let collapsed: boolean;
 
-	$: appointmentBlock = appointment.appointment_block;
-	$: instructionalMember = appointmentBlock.instructional_member;
-	$: startTime = appointment.appointment_block.start_time;
+	$: startTime = event.startTime;
 
 	let endTime: Date;
 
 	$: {
 		endTime = new Date(startTime);
-		endTime.setTime(endTime.getTime() + appointmentBlock.duration);
+		endTime.setTime(endTime.getTime() + event.duration);
+	}
+
+	let title: string;
+
+	$: {
+		let sectionMember: ExtendedSectionMember;
+
+		if (isCalendarEventAppointmentBlock(event.underlying)) {
+			sectionMember = event.underlying.instructional_member;
+		} else {
+			sectionMember = event.underlying.student;
+		}
+
+		title = sectionName(sectionMember.section);
+	}
+
+	let subtitle: string;
+
+	$: {
+		if (isCalendarEventAppointmentBlock(event.underlying)) {
+			const instructionalMemberUser = event.underlying.instructional_member.user;
+
+			if (instructionalMemberUser.id == userID) {
+				subtitle = "Your office hours";
+			} else {
+				subtitle = `${instructionalMemberUser.first_name} ${instructionalMemberUser.last_name}'s office hours`;
+			}
+		} else if (event.underlying.student.user.id == userID) {
+			const instructionalMemberUser = event.underlying.appointment_block.instructional_member.user;
+
+			subtitle = `Your booked appointment with ${instructionalMemberUser.first_name} ${instructionalMemberUser.last_name}`;
+		} else {
+			const studentUser = event.underlying.student.user;
+
+			subtitle = `${studentUser.first_name} ${studentUser.last_name}'s booked appointment with you`;
+		}
 	}
 
 	const dispatch = createEventDispatcher<{
-		click: undefined;
+		click: ExtendedAppointmentBlock;
 	}>();
 </script>
 
@@ -26,18 +62,16 @@
 	type="button"
 	class="card bg-primary shadow text-left"
 	class:calendar-card-collapsed={collapsed}
-	on:click={() => dispatch("click")}>
+	on:click={() => {
+		if (isCalendarEventAppointmentBlock(event.underlying)) {
+			dispatch("click", event.underlying);
+		}
+	}}>
 	<div class="card-body gap-0 p-4">
-		<h3 class="calendar-card-section font-medium text-sm">
-			{sectionName(instructionalMember.section)}
-		</h3>
-
+		<h3 class="calendar-card-section font-medium text-sm">{title}</h3>
 		<div class="calendar-card-additional-container">
 			<div class="calendar-card-additional">
-				<h2 class="card-title text-sm">
-					Office Hours with {userName(instructionalMember.user)}
-				</h2>
-
+				<h2 class="card-title text-sm">{subtitle}</h2>
 				<p class="text-sm">
 					{startTime.toLocaleString("en-US", {
 						timeStyle: "short"

--- a/src/lib/components/calendar/CalendarCardCarousel.svelte
+++ b/src/lib/components/calendar/CalendarCardCarousel.svelte
@@ -1,20 +1,30 @@
 <script lang="ts">
-	import type { ExtendedAppointment } from "$lib/types";
+	import type { CalendarEvent } from "$lib/components/calendar";
+	import type { ExtendedAppointmentBlock } from "$lib/types";
 	import { createEventDispatcher } from "svelte";
 	import CalendarCard from "./CalendarCard.svelte";
 
-	export let appointments: ExtendedAppointment[];
+	export let events: CalendarEvent[];
+	export let userID: string;
 
 	const dispatch = createEventDispatcher<{
-		appointmentClicked: ExtendedAppointment;
+		click: {
+			appointmentBlock: ExtendedAppointmentBlock;
+			appointmentDate: Date;
+		};
 	}>();
 </script>
 
 <div class="flex flex-col gap-2">
-	{#each appointments as appointment}
+	{#each events as calendarEvent}
 		<CalendarCard
-			{appointment}
-			collapsed={appointments.length > 1}
-			on:click={() => dispatch("appointmentClicked", appointment)} />
+			event={calendarEvent}
+			{userID}
+			collapsed={events.length > 1}
+			on:click={event =>
+				dispatch("click", {
+					appointmentBlock: event.detail,
+					appointmentDate: calendarEvent.date
+				})} />
 	{/each}
 </div>

--- a/src/lib/components/calendar/CalendarDaily.svelte
+++ b/src/lib/components/calendar/CalendarDaily.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { createEventDispatcher } from "svelte";
 	import {
+		type CalendarConfiguration,
+		type CalendarEvent,
 		calendarRowCount,
 		calendarStartAndEndTimes,
-		type CalendarConfiguration
+		dailyCalendarEvents
 	} from "$lib/components/calendar";
 
 	import CalendarCardCarousel from "$lib/components/calendar/CalendarCardCarousel.svelte";
@@ -11,42 +13,45 @@
 	import CalendarGutter from "$lib/components/calendar/CalendarGutter.svelte";
 	import { normalizeDateByDay, normalizeDateByTimeWithinDay } from "$lib/dateManipulation";
 	import { currentTime } from "$lib/stores";
-	import type { ExtendedAppointment } from "$lib/types";
+	import type { ExtendedAppointmentBlock } from "$lib/types";
 
 	export let configuration: CalendarConfiguration;
 
 	$: dateNormalized = normalizeDateByDay(configuration.currentDate);
-
-	const [startTime, endTime] = calendarStartAndEndTimes(
+	$: events = dailyCalendarEvents(
 		configuration.appointments,
+		configuration.appointmentBlocks,
+		dateNormalized
+	);
+
+	$: [startTime, endTime] = calendarStartAndEndTimes(
+		events,
 		configuration.maximumStartTime,
 		configuration.minimumEndTime
 	);
 
-	const rowCount = calendarRowCount(startTime, endTime, configuration.timeIncrement);
+	$: rowCount = calendarRowCount(startTime, endTime, configuration.timeIncrement);
 
-	let cellAppointments: ExtendedAppointment[][];
+	let cellEvents: CalendarEvent[][];
 
 	$: {
-		cellAppointments = [];
+		cellEvents = [];
 
 		for (let i = 0; i < rowCount; i++) {
-			cellAppointments.push([]);
+			cellEvents.push([]);
 		}
 
-		configuration.appointments.forEach(appointment => {
+		events.forEach(event => {
 			const i =
-				Math.floor(
-					normalizeDateByTimeWithinDay(appointment.appointment_block.start_time).getTime() -
-						startTime.getTime()
-				) / configuration.timeIncrement;
+				Math.floor(normalizeDateByTimeWithinDay(event.startTime).getTime() - startTime.getTime()) /
+				configuration.timeIncrement;
 
 			if (
 				i >= 0 &&
 				i < rowCount &&
-				normalizeDateByDay(appointment.appointment_day).getTime() == dateNormalized.getTime()
+				normalizeDateByDay(event.date).getTime() == dateNormalized.getTime()
 			) {
-				cellAppointments[i]?.push(appointment);
+				cellEvents[i]?.push(event);
 			}
 		});
 	}
@@ -54,7 +59,10 @@
 	$: currentTimeNormalized = normalizeDateByTimeWithinDay($currentTime);
 
 	const dispatch = createEventDispatcher<{
-		appointmentClicked: ExtendedAppointment;
+		click: {
+			appointmentBlock: ExtendedAppointmentBlock;
+			appointmentDate: Date;
+		};
 	}>();
 
 	const gutterTopMargin = "1rem";
@@ -74,15 +82,18 @@
 		</thead>
 
 		<tbody class="relative">
-			{#each cellAppointments as appointments, i}
+			{#each cellEvents as events, i}
 				<tr>
 					<td class="border-neutral border-e border-s p-0" class:border-b={i < rowCount - 1}>
 						<div
 							class="overflow-y-scroll p-2 relative z-10"
 							style:height={configuration.gutterCellHeight}>
 							<CalendarCardCarousel
-								{appointments}
-								on:appointmentClicked={event => dispatch("appointmentClicked", event.detail)} />
+								{events}
+								userID={configuration.userID}
+								on:click={event => {
+									dispatch("click", event.detail);
+								}} />
 						</div>
 					</td>
 				</tr>

--- a/src/lib/components/calendar/index.ts
+++ b/src/lib/components/calendar/index.ts
@@ -1,7 +1,14 @@
-import { normalizeDateByTimeWithinDay } from "$lib/dateManipulation";
-import type { ExtendedAppointment } from "$lib/types";
+import {
+	normalizeDateByDay,
+	normalizeDateByTimeWithinDay,
+	normalizeDateByWeek
+} from "$lib/dateManipulation";
+import { weekDayIndex, type ExtendedAppointment, type ExtendedAppointmentBlock } from "$lib/types";
 
 export interface CalendarConfiguration {
+	appointments: ExtendedAppointment[];
+	appointmentBlocks: ExtendedAppointmentBlock[];
+
 	/**
 	 * If the calendar is daily, the date the calendar will be focused on. Otherwise,
 	 * the date whose week the calendar will be focused on. Note that in the former case,
@@ -11,14 +18,21 @@ export interface CalendarConfiguration {
 	currentDate: Date;
 
 	/**
+	 * The height of each calendar gutter cell as a CSS expression.
+	 *
+	 * Note: Don't provide any user-supplied values here, since this is vulnerable to injection.
+	 */
+	gutterCellHeight: string;
+
+	/**
 	 * The minimum time to display on a given day. Note that this time will be decreased to
-	 * accomodate any appointments that fall before it.
+	 * accommodate any appointments that fall before it.
 	 */
 	maximumStartTime: Date;
 
 	/**
 	 * The maximum time to display on a given day. Note that this time will be increased to
-	 * accomodate any appointments that fall after it.
+	 * accommodate any appointments that fall after it.
 	 */
 	minimumEndTime: Date;
 
@@ -26,14 +40,18 @@ export interface CalendarConfiguration {
 	 * The length of time, in milliseconds, that a cell on the calendar measures.
 	 */
 	timeIncrement: number;
-	appointments: ExtendedAppointment[];
+	userID: string;
+}
 
-	/**
-	 * The height of each calendar gutter cell as a CSS expression.
-	 *
-	 * Note: Don't provide any user-supplied values here, since this is vulnerable to injection.
-	 */
-	gutterCellHeight: string;
+/**
+ * Encapsulates both appointment blocks and appointments to simplify displaying both of them on the
+ * calendar.
+ */
+export interface CalendarEvent {
+	date: Date;
+	duration: number;
+	startTime: Date;
+	underlying: ExtendedAppointmentBlock | ExtendedAppointment;
 }
 
 export enum CalendarMode {
@@ -41,32 +59,124 @@ export enum CalendarMode {
 	Weekly = "weekly"
 }
 
+function appointmentBlockToCalendarEvent(
+	appointmentBlock: ExtendedAppointmentBlock,
+	date: Date
+): CalendarEvent {
+	return {
+		date,
+		duration: appointmentBlock.duration,
+		startTime: appointmentBlock.start_time,
+		underlying: appointmentBlock
+	};
+}
+
+function appointmentToCalendarEvent(appointment: ExtendedAppointment): CalendarEvent {
+	return {
+		date: appointment.appointment_day,
+		duration: appointment.appointment_block.duration,
+		startTime: appointment.appointment_block.start_time,
+		underlying: appointment
+	};
+}
+
 export function calendarRowCount(startTime: Date, endTime: Date, timeIncrement: number): number {
 	return (endTime.getTime() - startTime.getTime()) / timeIncrement;
 }
 
 export function calendarStartAndEndTimes(
-	appointments: ExtendedAppointment[],
+	events: CalendarEvent[],
 	maximumStartTime: Date,
 	minimumEndTime: Date
 ): [Date, Date] {
 	const startTime = new Date(
 		Math.min(
-			...[
-				...appointments.map(appointment => appointment.appointment_block.start_time),
-				maximumStartTime
-			].map(time => normalizeDateByTimeWithinDay(time).getTime())
+			...[...events.map(event => event.startTime), maximumStartTime].map(time =>
+				normalizeDateByTimeWithinDay(time).getTime()
+			)
 		)
 	);
 
 	const endTime = new Date(
 		Math.max(
-			...[
-				...appointments.map(appointment => appointment.appointment_block.start_time),
-				minimumEndTime
-			].map(time => normalizeDateByTimeWithinDay(time).getTime())
+			...[...events.map(event => event.startTime), minimumEndTime].map(time =>
+				normalizeDateByTimeWithinDay(time).getTime()
+			)
 		)
 	);
 
 	return [startTime, endTime];
+}
+
+export function dailyCalendarEvents(
+	appointments: ExtendedAppointment[],
+	appointmentBlocks: ExtendedAppointmentBlock[],
+	currentDate: Date
+): CalendarEvent[] {
+	const normalizedCurrentDate = normalizeDateByDay(currentDate);
+	const todaysAppointments = appointments.filter(
+		appointment =>
+			normalizeDateByDay(appointment.appointment_day).getTime() == normalizedCurrentDate.getTime()
+	);
+
+	const appointmentEvents = todaysAppointments.map(appointment =>
+		appointmentToCalendarEvent(appointment)
+	);
+
+	const appointmentBlockEvents = excludeBookedAppointmentBlocks(
+		appointmentBlocks,
+		todaysAppointments
+	)
+		.filter(appointmentBlock => weekDayIndex(appointmentBlock.week_day) == currentDate.getDay())
+		.map(appointmentBlock => appointmentBlockToCalendarEvent(appointmentBlock, currentDate));
+
+	return [...appointmentEvents, ...appointmentBlockEvents];
+}
+
+export function excludeBookedAppointmentBlocks(
+	appointmentBlocks: ExtendedAppointmentBlock[],
+	appointments: ExtendedAppointment[]
+): ExtendedAppointmentBlock[] {
+	const appointmentAppointmentBlockIds = new Set(
+		appointments.map(appointment => appointment.appointment_block.id)
+	);
+
+	return appointmentBlocks.filter(
+		appointmentBlock => !appointmentAppointmentBlockIds.has(appointmentBlock.id)
+	);
+}
+
+export function isCalendarEventAppointmentBlock(
+	underlying: ExtendedAppointment | ExtendedAppointmentBlock
+): underlying is ExtendedAppointmentBlock {
+	return "instructional_member_id" in underlying;
+}
+
+export function weeklyCalendarEvents(
+	appointments: ExtendedAppointment[],
+	appointmentBlocks: ExtendedAppointmentBlock[],
+	currentWeek: Date
+): CalendarEvent[] {
+	const normalizedCurrentWeek = normalizeDateByWeek(currentWeek);
+	const thisWeeksAppointments = appointments.filter(
+		appointment =>
+			normalizeDateByWeek(appointment.appointment_day).getTime() == normalizedCurrentWeek.getTime()
+	);
+
+	const appointmentEvents = thisWeeksAppointments.map(appointment =>
+		appointmentToCalendarEvent(appointment)
+	);
+
+	const appointmentBlockEvents = excludeBookedAppointmentBlocks(
+		appointmentBlocks,
+		thisWeeksAppointments
+	).map(appointmentBlock => {
+		const date = new Date(currentWeek);
+
+		date.setDate(date.getDate() + weekDayIndex(appointmentBlock.week_day));
+
+		return appointmentBlockToCalendarEvent(appointmentBlock, date);
+	});
+
+	return [...appointmentEvents, ...appointmentBlockEvents];
 }

--- a/src/lib/db/appointmentBlocks.ts
+++ b/src/lib/db/appointmentBlocks.ts
@@ -24,14 +24,14 @@ export async function createAppointmentBlock(
 		const query: QueryConfig = {
 			text: `
 				INSERT INTO appointment_blocks (id, instructional_member_id, week_day, start_time, duration)
-				VALUES ($1, $2, $3, $4, $5)
+				VALUES ($1, $2, $3, $4, $5::interval)
 			`,
 			values: [
 				newAppointmentBlock.id,
 				newAppointmentBlock.instructional_member_id,
 				newAppointmentBlock.week_day,
 				newAppointmentBlock.start_time.toLocaleTimeString(),
-				newAppointmentBlock.duration
+				`${newAppointmentBlock.duration} milliseconds`
 			]
 		};
 

--- a/src/lib/db/sectionMembers.ts
+++ b/src/lib/db/sectionMembers.ts
@@ -104,25 +104,23 @@ WHERE id = ANY($1)`,
 	);
 }
 
-export async function getSectionSectionMembers(sectionId: string): Promise<SectionMember[]> {
+export async function getSectionsSectionMembers(sectionIds: string[]): Promise<SectionMember[]> {
+	if (sectionIds.length == 0) {
+		return [];
+	}
+
 	return withConnection(async client => {
 		const query: QueryConfig = {
 			text: `
-				SELECT
-					sm.id,
-					sm.section_id,
-					sm.user_id,
-					sm.member_type,
-					sm.is_restricted
-				FROM section_members sm
-				WHERE sm.section_id = $1
-			`,
-			values: [sectionId]
+SELECT id, section_id, user_id, member_type, is_restricted
+FROM section_members
+WHERE section_id = ANY($1)`,
+			values: [sectionIds]
 		};
 
-		const res: QueryResult<SectionMember> = await client.query(query);
-		const sectionMembers = res.rows;
-		return sectionMembers;
+		const result: QueryResult<SectionMember> = await client.query(query);
+
+		return result.rows;
 	});
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -127,3 +127,22 @@ export function isSectionMemberStudent(
 ): sectionMember is Student {
 	return sectionMember.member_type == SectionMemberType.Student;
 }
+
+export function weekDayIndex(weekDay: WeekDay): number {
+	switch (weekDay) {
+		case WeekDay.Sunday:
+			return 0;
+		case WeekDay.Monday:
+			return 1;
+		case WeekDay.Tuesday:
+			return 2;
+		case WeekDay.Wednesday:
+			return 3;
+		case WeekDay.Thursday:
+			return 4;
+		case WeekDay.Friday:
+			return 5;
+		case WeekDay.Saturday:
+			return 6;
+	}
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -31,15 +31,9 @@ export function postgresTimeWithTimeZoneToDate(timeWithZone: string): Date | Err
 		);
 	}
 
-	const parsedTimeZoneOffset = parseInt(timeZoneOffset);
-
-	if (isNaN(parsedTimeZoneOffset)) {
-		return new Error(`This PostgreSQL timestamp's timezone offset isn't numeric: ${timeWithZone}`);
-	}
-
 	const date = new Date(0);
 
-	date.setHours(hours - parsedTimeZoneOffset);
+	date.setHours(hours);
 	date.setMinutes(minutes);
 
 	return date;

--- a/src/routes/(signed_in)/calendar/+page.svelte
+++ b/src/routes/(signed_in)/calendar/+page.svelte
@@ -5,16 +5,7 @@
 	import CalendarDaily from "$lib/components/calendar/CalendarDaily.svelte";
 	import Header from "$lib/components/Header.svelte";
 	import CalendarWeekly from "$lib/components/calendar/CalendarWeekly.svelte";
-	import {
-		SectionMemberType,
-		WeekDay,
-		type InstructionalMember,
-		type Student,
-		type ExtendedAppointment
-	} from "$lib/types";
-	import { title } from "$lib/stores";
-
-	title.set("Calendar");
+	import { type ExtendedAppointmentBlock } from "$lib/types";
 	import type { PageData } from "./$types";
 
 	export let data: PageData;
@@ -31,19 +22,29 @@
 	let calendarMode = CalendarMode.Weekly;
 
 	$: calendarConfiguration = {
+		appointments: data.appointments,
+		appointmentBlocks: data.appointmentBlocks,
 		currentDate: calendarDate,
+		gutterCellHeight: "8rem",
 		maximumStartTime: calendarStartTime,
 		minimumEndTime: calendarEndTime,
 		timeIncrement: 30 * 60 * 1000,
-		appointments: data.appointments,
-		gutterCellHeight: "8rem"
+		userID: data.userID
 	};
 
-	let bookingAppointment: ExtendedAppointment | undefined;
+	let bookingModalData:
+		| {
+				appointmentBlock: ExtendedAppointmentBlock;
+				appointmentDate: Date;
+		  }
+		| undefined;
+
 	let bookingModalOpen = false;
 
-	function handleAppointmentClicked(event: CustomEvent<ExtendedAppointment>) {
-		bookingAppointment = event.detail;
+	function handleAppointmentClick(
+		event: CustomEvent<{ appointmentBlock: ExtendedAppointmentBlock; appointmentDate: Date }>
+	) {
+		bookingModalData = event.detail;
 		bookingModalOpen = true;
 	}
 </script>
@@ -61,16 +62,18 @@
 		{#if calendarMode == CalendarMode.Daily}
 			<CalendarDaily
 				configuration={calendarConfiguration}
-				on:appointmentClicked={event => handleAppointmentClicked(event)} />
+				on:appointmentBlockClick={event => handleAppointmentClick(event)} />
 		{:else}
 			<CalendarWeekly
 				configuration={calendarConfiguration}
-				on:appointmentClicked={event => handleAppointmentClicked(event)} />
+				on:appointmentBlockClick={event => handleAppointmentClick(event)} />
 		{/if}
 	</div>
 </div>
 
 <CalendarBookingModal
-	appointment={bookingAppointment}
+	data={bookingModalData}
 	isOpen={bookingModalOpen}
-	on:close={() => (bookingModalOpen = false)} />
+	on:close={() => {
+		bookingModalOpen = false;
+	}} />

--- a/src/routes/(signed_in)/courses/[courseID]/sections/[sectionID]/+page.server.ts
+++ b/src/routes/(signed_in)/courses/[courseID]/sections/[sectionID]/+page.server.ts
@@ -1,5 +1,5 @@
 import { verifyAuthentication, verifyUserIsApartOfInstructionalTeam } from "$lib/auth";
-import { extendSectionMembers, getSectionSectionMembers } from "$lib/db/sectionMembers";
+import { extendSectionMembers, getSectionsSectionMembers } from "$lib/db/sectionMembers";
 import { extendSections, getSection } from "$lib/db/sections";
 import type { PageServerLoad, Actions } from "./$types";
 import { error } from "@sveltejs/kit";
@@ -28,7 +28,7 @@ export const load: PageServerLoad = async ({ locals, cookies, params }) => {
 		throw new Error(`I didn't get back a section with the ID ${section.id}`);
 	}
 
-	const sectionMembers = await getSectionSectionMembers(sectionID);
+	const sectionMembers = await getSectionsSectionMembers([sectionID]);
 
 	if (sectionMembers.length === 0) {
 		error(400, "Must have section members to view this page.");


### PR DESCRIPTION
![Screenshot 2024-04-30 at 13-55-19 Screenshot](https://github.com/DylanHalstead/ClassConnect/assets/13180372/26951420-db29-43a4-a88d-7e9df2450173)

This PR modifies the calendar to display both appointments and appointment blocks (previously, we were only showing the user's appointment blocks as a TA). We use the following phrasing when displaying appointments and appointment blocks:

1. Your appointment block as a TA: "Your office hours"
2. Your appointment as a TA: "X's booked session with you"
3. Your TA's appointment block as a student: "X's office hours"
4. Your appointment as a student: "Your booked session with X"

Part 3 (the final part) will modify the booking modal to send a request to the backend.